### PR TITLE
Reinstate work order events, and include jobs in them

### DIFF
--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -42,6 +42,10 @@ class Job < ApplicationRecord
   scope :cancelled, -> { where.not(cancelled: nil) }
   scope :concluded, -> { completed.or(cancelled) }
 
+  def name
+    "Job #{id}"
+  end
+
   # Before modifying the state for an object, it checks that the pre-conditions for each step have
   # been met
   def status_ready_for_update

--- a/app/models/work_order.rb
+++ b/app/models/work_order.rb
@@ -129,14 +129,15 @@ class WorkOrder < ApplicationRecord
     end
   end
 
-  def generate_dispatched_event
+  def generate_dispatched_event(forwarded_jobs)
     begin
       if active?
-        message = WorkOrderEventMessage.new(work_order: self, status: 'dispatched')
+        message = WorkOrderEventMessage.new(work_order: self, status: 'dispatched',
+                    forwarded_jobs: forwarded_jobs, dispatched_jobs: jobs)
         BrokerHandle.publish(message)
         BillingFacadeClient.send_event(self, 'dispatched')
       else
-        Rails.logger.error("dispatched event cannot be generated from a work order that is not active.")
+        Rails.logger.error('Dispatched event cannot be generated from a work order that is not active.')
       end
     rescue => e
       Rails.logger.error e

--- a/app/services/dispatch_next_order_service.rb
+++ b/app/services/dispatch_next_order_service.rb
@@ -60,6 +60,7 @@ class DispatchNextOrderService
     return error("This is the last process in the product.") if old_process==product.processes.last
     return error("Jobs that have already been forwarded to the next process cannot be forwarded again.") if jobs.any? { |job| job.forwarded }
     return error("This plan is in a broken state.") if plan.broken?
+    return false unless helper.check_broker
     validate_sets
   end
 
@@ -129,6 +130,8 @@ private
 
     # Do this last because it cannot be undone
     combined_set.update_attributes(owner_id: @order.owner_email, locked: true)
+    
+    @order.reload.generate_dispatched_event(jobs)
 
     true
   end

--- a/app/services/dispatch_plan_service.rb
+++ b/app/services/dispatch_plan_service.rb
@@ -47,11 +47,6 @@ class DispatchPlanService
     return false
   end
 
-  def generate_dispatched_event(order_id)
-    order = WorkOrder.find(order_id)
-    order.generate_dispatched_event
-  end
-
   def predict_plan_cost
     @plan_unit_price = nil
 
@@ -101,6 +96,8 @@ private
       Rails.logger.error work_order_dispatcher.errors.full_messages
       raise "The request to the LIMS failed."
     end
+
+    order.reload.generate_dispatched_event([])
 
     true
   end

--- a/spec/models/job_spec.rb
+++ b/spec/models/job_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Job, type: :model do
-  context '#validation' do
+  describe '#validation' do
     it 'is not valid without a work order' do
       expect(build(:job, work_order: nil)).not_to be_valid
     end
@@ -18,7 +18,14 @@ RSpec.describe Job, type: :model do
 
   end
 
-  context '#status' do
+  describe '#name' do
+    it 'should be correct' do
+      job = create(:job)
+      expect(job.name).to eq("Job #{job.id}")
+    end
+  end
+
+  describe '#status' do
     let(:job) { create :job }
 
     it 'checks when the job is broken' do

--- a/spec/services/dispatch_plan_service_spec.rb
+++ b/spec/services/dispatch_plan_service_spec.rb
@@ -199,6 +199,10 @@ RSpec.describe :dispatch_plan_service do
 
   context 'when nothing goes wrong' do
     before do
+      allow_any_instance_of(WorkOrder).to receive(:generate_dispatched_event) do |order, forwarded_jobs|
+        @event_order = order
+        @event_forwarded_jobs = forwarded_jobs
+      end
       @result = service.perform
       @order = plan.reload.work_orders.first
     end
@@ -231,6 +235,11 @@ RSpec.describe :dispatch_plan_service do
 
     it 'should have dispatched the order' do
       expect(dispatcher).to have_received(:dispatch).with(@order)
+    end
+
+    it 'should have tried to dispatch an event message with the correct arguments' do
+      expect(@event_order).to eq(@order)
+      expect(@event_forwarded_jobs).to be_empty
     end
   end
 


### PR DESCRIPTION
a299 missed some code required to send work order events.
This commit reinstates them, and adds jobs as subjects,
which is required for forthcoming stories.