### PR TITLE
Don't show unhelpful "Internal Server Error" when ubw is down

### DIFF
--- a/app/helpers/plan_wizard_helper.rb
+++ b/app/helpers/plan_wizard_helper.rb
@@ -18,6 +18,6 @@ module PlanWizardHelper
     return {} unless parent_cost_code
     module_names = work_plan.product.processes.flat_map(&:process_modules).map(&:name)
 
-    UbwClient::get_unit_prices(module_names, parent_cost_code)
+    UbwClient::get_unit_prices_or_nil(module_names, parent_cost_code) || {}
   end
 end

--- a/app/javascript/components/cost_information.js
+++ b/app/javascript/components/cost_information.js
@@ -11,6 +11,7 @@ const CostInformation = (props) => {
       <div className="col-md-6">
         <h5>Cost Information</h5>
         <pre>{`Number of samples: ${numSamples}`}
+          <br/>
           <span className="wrappable" style={{color: 'red'}}>&#9888; {`${errorText}`}</span>
         </pre>
       </div>

--- a/app/policy/dispatchable_work_order_policy.rb
+++ b/app/policy/dispatchable_work_order_policy.rb
@@ -57,7 +57,7 @@ class DispatchableWorkOrderPolicy
   end
 
   def bad_module_names
-    @bad_module_names ||= UbwClient.missing_unit_prices(process_module_names, cost_code)
+    @bad_module_names ||= UbwClient::missing_unit_prices(process_module_names, cost_code)
   end
 
   def process_module_names

--- a/app/services/plan_helper.rb
+++ b/app/services/plan_helper.rb
@@ -92,8 +92,10 @@ class PlanHelper
       error("No modules specified.")
       return nil
     end
-
-    module_costs = UbwClient::get_unit_prices(module_names, cost_code)
+    module_costs = UbwClient::get_unit_prices_or_nil(module_names, cost_code)
+    if module_costs.nil?
+      return error("There was a problem retrieving information from UBW.")
+    end
 
     uncosted = module_names.uniq - module_costs.select { |k,v| v.present? }.keys
 

--- a/lib/ubw_client.rb
+++ b/lib/ubw_client.rb
@@ -14,6 +14,16 @@ module UbwClient
     end
   end
 
+  # Calls get_unit_prices, catches exceptions, logs them and returns nil
+  def self.get_unit_prices_or_nil(module_names, cost_code)
+    return get_unit_prices(module_names, cost_code)
+  rescue StandardError => e
+    Rails.logger.error "UbwClient::get_unit_prices failed"
+    Rails.logger.error e
+    e.backtrace.each { |x| Rails.logger.error x }
+    return nil
+  end
+
   # Looks up the prices of modules by name with the given cost code.
   # Returns the set of given module names that do not have a unit price for the given cost code.
   def self.missing_unit_prices(module_names, cost_code)
@@ -32,6 +42,7 @@ module UbwClient
   def self.valid_module_names(module_names)
     Ubw::Price.where(module_name: module_names).map(&:module_name).to_set
   end
+
 
   # Looks up the modules by name without a cost code.
   # Module names are invalid if they have no listed price for any cost code.

--- a/spec/lib/ubw_client_spec.rb
+++ b/spec/lib/ubw_client_spec.rb
@@ -120,4 +120,19 @@ RSpec.describe 'UbwClient' do
     end
   end
 
+  describe '#get_unit_prices_or_nil' do
+    context 'when the lookup succeeds' do
+      it 'should return a hash containing the correct price' do
+        expected = { 'alpha' => BigDecimal.new('201.00') }
+        expect(UbwClient::get_unit_prices_or_nil('alpha', 'S0001')).to eq(expected)
+      end
+    end
+
+    context 'when the lookup errors' do
+      it 'should return nil' do
+        expect(Ubw::Price).to receive(:where).and_raise(Ubw::Errors::ClientError)
+        expect(UbwClient::get_unit_prices_or_nil('alpha', 'S0001')).to be_nil
+      end
+    end
+  end
 end


### PR DESCRIPTION
Added UbwClient::get_unit_prices_or_nil, which catches and logs exceptions.
Several places now use that method, check if the result is nil, and emit something like
"There was a problem retrieving info from UBW."